### PR TITLE
Makefile: add “clean” target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,4 +12,7 @@ devdocs:
 	rm -rf doc
 	rustdoc --no-defaults --passes "collapse-docs" --passes "unindent-comments" lib.rs
 
+clean:
+	rm -f libxot-*.rlib
+
 .PHONY: warnings all


### PR DESCRIPTION
Not sure if it's necessary, but why not?
