### PR TITLE
update to recent rust changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 all:
 	rustc lib.rs
 
+warn:
+	rustc --no-trans lib.rs -A dead-code -A unused-variable -A unused-imports -A unused-must-use -A unused-mut
+
 warnings:
 	rustc --no-trans lib.rs
 

--- a/cryptocons.rs
+++ b/cryptocons.rs
@@ -12,7 +12,7 @@ static CRYPTO_HANDSHAKE: u8 = 2;
 static CRYPTO_PACKET: u8 = 3;
 static HANDSHAKE_TIMEOUT: u64 = 10;
 
-#[deriving(Eq)]
+#[deriving(PartialEq, Eq)]
 enum ConnectionStatus {
     HandshakeSent,
     NotConfirmed,
@@ -146,7 +146,7 @@ struct RawConnection {
 
 impl RawConnection {
     fn new() -> RawConnection {
-        unsafe { mem::uninit() }
+        unsafe { mem::uninitialized() }
     }
 }
 

--- a/dht.rs
+++ b/dht.rs
@@ -7,11 +7,11 @@ use utils;
 use utils::{other_error, StructWriter, CryptoWriter, StructReader, CryptoReader,
             SlicableReader};
 use utils::bufreader::{BufReader};
-use rand::{task_rng, Rng};
+use std::rand::{task_rng, Rng};
 use std::{mem};
 use std::slice::{Items, MutItems};
 use keylocker::{Keylocker};
-use collections::hashmap::{HashMap};
+use std::collections::hashmap::{HashMap};
 use ping::{PingControl};
 
 static MAX_SENT_NODES: uint = 4;
@@ -342,8 +342,8 @@ impl DHT {
             return Err(());
         }
         let lan_ok = false;
-        let MAX_TRIES = 6;
-        for _ in range(0, MAX_TRIES) {
+        let max_tries = 6;
+        for _ in range::<uint>(0, max_tries) {
             let friend_num = task_rng().gen_range(0, self.friends.len());
             let (_, friend) = self.friends.mut_iter().nth(friend_num).unwrap();
             match friend.clients.random_node(lan_ok) {
@@ -357,7 +357,7 @@ impl DHT {
         if nodes.len() != 3 {
             return Err(())
         }
-        let mut rv: [Node, ..3] = unsafe { mem::uninit() };
+        let mut rv: [Node, ..3] = unsafe { mem::uninitialized() };
         for (i, v) in nodes.move_iter().enumerate() {
             rv[i] = v;
         }
@@ -397,7 +397,7 @@ impl ClientList {
         if possible.len() == 0 {
             return None;
         }
-        let (i, kind) = task_rng().choose(possible.as_slice());
+        let &(i, kind) = task_rng().choose(possible.as_slice()).unwrap();
         let client = self.clients.get_mut(i);
         let addr = match kind {
             IPv4 => client.assoc4.addr,
@@ -475,7 +475,7 @@ impl ClientList {
                 }
                 nodes.pop();
                 let mut n = nodes.len();
-                while (n > 0) {
+                while n > 0 {
                     if close_to.cmp(&cand.id, &nodes.get(n-1).id) == Greater {
                         break;
                     }
@@ -532,7 +532,7 @@ impl ClientList {
         if (self.get_node_timed_out() || self.can_bootstrap()) && possible.len() > 0 {
             self.last_get_node = utils::time::sec();
             self.bootstrap_times += 1;
-            let (i, family) = task_rng().choose(possible.as_slice());
+            let &(i, family) = task_rng().choose(possible.as_slice()).unwrap();
             let client = self.clients.get(i);
             let addr = match family {
                 IPv4 => client.assoc4.addr,
@@ -595,7 +595,7 @@ impl TimedSocketAddr {
     }
 
     fn new() -> TimedSocketAddr {
-        unsafe { mem::init() }
+        unsafe { mem::zeroed() }
     }
 
     fn is_bad(&self) -> bool {

--- a/groups.rs
+++ b/groups.rs
@@ -96,7 +96,7 @@ impl Group {
         self.send_to_all(packet.unwrap().as_slice())
     }
 
-    fn set_nick(&mut self, nick: ~str) -> IoResult<()> {
+    fn set_nick(&mut self, nick: String) -> IoResult<()> {
         self.nick = nick;
         self.send_nick()
     }

--- a/keylocker.rs
+++ b/keylocker.rs
@@ -5,7 +5,7 @@
 use crypt::{Key, SecretKey, PrecomputedKey};
 use time::{get_time};
 use std::{u8,u64};
-use std::cast::{transmute_lifetime};
+use std::mem::{transmute};
 
 /// Time in seconds before the precomputed key is considered dead.
 static TIMEOUT:       i64 = 600;
@@ -61,7 +61,7 @@ impl<'a> Keylocker {
                 entry.request_count += 1;
                 entry.last_requested = get_time().sec;
                 // Borrow checker thinks this return doesn't stop the loop.
-                return unsafe { transmute_lifetime(&entry.computed) };
+                return unsafe { transmute(&entry.computed) };
             }
             if min_requested > 0 {
                 if entry.timed_out() {

--- a/lib.rs
+++ b/lib.rs
@@ -1,4 +1,4 @@
-#![crate_id = "xot"]
+#![crate_name = "xot"]
 #![crate_type = "lib"]
 #![feature(globs)]
 #![feature(macro_rules)]

--- a/ludp.rs
+++ b/ludp.rs
@@ -4,10 +4,9 @@ use utils;
 use utils::ringbuffer::{XBuffer, RingBuffer};
 use utils::{other_error, StructReader, StructWriter, FiniteReader};
 use std::io::net::ip::{SocketAddr, Ipv4Addr, Ipv6Addr};
-use std::mem::{to_be16};
-use std::cast::{transmute};
+use std::mem::{transmute};
 use std::{u64};
-use rand::{task_rng, Rng};
+use std::rand::{task_rng, Rng};
 use net::sockets::{UdpWriter};
 
 static DEFAULT_QUEUE_LEN: uint = 4;
@@ -15,7 +14,7 @@ static MAX_QUEUE_LEN:     uint = 1024;
 static MAX_DATA_SIZE:     uint = 1024;
 static CON_TIMEOUT:       f64  = 5.0;
 
-#[deriving(Eq)]
+#[deriving(PartialEq)]
 enum ConnectionStatus {
     NoConnection,
     HandshakeSending,
@@ -274,7 +273,7 @@ impl<'a> LosslessUDP {
         let mut id = 0u32;
         let mut i = 0u;
 
-        let port: [u8, ..2] = unsafe { transmute(to_be16(addr.port)) };
+        let port: [u8, ..2] = unsafe { transmute(addr.port.to_be()) };
         id ^= self.rand_get(&mut i, port[0]);
         id ^= self.rand_get(&mut i, port[1]);
         match addr.ip {
@@ -285,8 +284,8 @@ impl<'a> LosslessUDP {
                 id ^= self.rand_get(&mut i, d);
             },
             Ipv6Addr(a, b, c, d, e, f, g, h) => {
-                let x = [to_be16(a), to_be16(b), to_be16(c), to_be16(d),
-                         to_be16(e), to_be16(f), to_be16(g), to_be16(h)];
+                let x = [a.to_be(), b.to_be(), c.to_be(), d.to_be(),
+                         e.to_be(), f.to_be(), g.to_be(), h.to_be()];
                 let x: [u8, ..16] = unsafe { transmute(x) };
                 for v in x.iter() {
                     id ^= self.rand_get(&mut i, *v);

--- a/net/mod.rs
+++ b/net/mod.rs
@@ -6,8 +6,7 @@ use libc::{AF_INET, AF_INET6, c_int};
 use net::sockets::{UdpWriter, UdpReader};
 use crypt::{Key};
 use std::{mem};
-use std::mem::{to_be16, from_be16};
-use std::cast::{transmute};
+use std::mem::{transmute, to_be16, from_be16};
 
 pub mod sockets;
 
@@ -18,7 +17,7 @@ pub struct Node {
 
 impl Node {
     pub fn new() -> Node {
-        unsafe { mem::init() }
+        unsafe { mem::zeroed() }
     }
 
     pub fn parse4(data: &[u8]) -> IoResult<Vec<Node>> {
@@ -174,8 +173,8 @@ impl IpAddrInfo for IpAddr {
             },
             Ipv6Addr(a, b, c, d, e, f, g, h) => {
                 let x: [u8, ..16] = unsafe {
-                    let arr = [to_be16(a), to_be16(b), to_be16(c), to_be16(d),
-                               to_be16(e), to_be16(f), to_be16(g), to_be16(h)];
+                    let arr = [a.to_be(), b.to_be(), c.to_be(), d.to_be(),
+                               e.to_be(), f.to_be(), g.to_be(), h.to_be()];
                     transmute(arr)
                 };
                 if x[0] == 0xFF && x[1] < 3 && x[15] == 1 {
@@ -215,8 +214,8 @@ impl IpAddrInfo for IpAddr {
             Ipv4Addr(a, b, c, d) => a == 255 && b == 255 && c == 255 && d == 255,
             Ipv6Addr(a, b, c, d, e, f, g, h) =>
                 // all nodes multicast
-                a == from_be16(0xFF02) && b == 0 && c == 0 && d == 0 && e == 0 &&
-                    f == 0 && g == 0 && h == from_be16(0x0001),
+                a == Int::from_be(0xFF02) && b == 0 && c == 0 && d == 0 && e == 0 &&
+                    f == 0 && g == 0 && h == Int::from_be(0x0001),
         }
     }
 }

--- a/net/sockets/options_int.rs
+++ b/net/sockets/options_int.rs
@@ -2,7 +2,7 @@ use libc::{c_int, c_void, socklen_t};
 use libc::{SOL_SOCKET, SO_BROADCAST, IPPROTO_IPV6, IPV6_ADD_MEMBERSHIP};
 
 use std::mem;
-use std::cast::{transmute};
+use std::mem::{transmute};
 
 use self::options::structs::*;
 

--- a/net/sockets/select.rs
+++ b/net/sockets/select.rs
@@ -14,7 +14,7 @@ mod select {
     #[link(name = "ws2_32")]
     extern "system" {
         pub fn select(nfds: c_int, readfds: *mut FdSetInt, writefds: *mut FdSetInt,
-                      exceptfds: *mut FdSetInt, timeout: *timeval) -> c_int;
+                      exceptfds: *mut FdSetInt, timeout: *const timeval) -> c_int;
     }
 
     pub static FD_SETSIZE: uint = 64;
@@ -30,7 +30,7 @@ mod select {
 
     impl FdSet {
         pub fn zero() -> FdSet {
-            unsafe { mem::init() }
+            unsafe { mem::zeroed() }
         }
 
         pub fn set(&mut self, fd: sock_t) {
@@ -81,7 +81,7 @@ mod select {
 
     extern {
         fn select(nfds: c_int, readfds: *mut FdSetInt, writefds: *mut FdSetInt,
-                  errorfds: *mut FdSetInt, timeout: *timeval) -> c_int;
+                  errorfds: *mut FdSetInt, timeout: *const timeval) -> c_int;
     }
 
     #[cfg(target_os = "macos")]
@@ -109,7 +109,7 @@ mod select {
     impl FdSet {
         /// Returns an empty `FdSet`.
         pub fn zero() -> FdSet {
-            unsafe { mem::init() }
+            unsafe { mem::zeroed() }
         }
 
         /// Sets a file descriptor.

--- a/onion/client.rs
+++ b/onion/client.rs
@@ -10,8 +10,8 @@ use utils::bufreader::{BufReader};
 use utils::{other_error, Choice, One, Two, StructReader, StructWriter, CryptoWriter,
             SlicableReader, CryptoReader};
 use net::{Node, IpAddrInfo};
-use rand;
-use rand::{task_rng, Rng};
+use std::rand;
+use std::rand::{task_rng, Rng};
 use onion::pipe::{PipeControl};
 use onion::consts::{META_REQUEST, ONION_FORWARD_REQUEST, FAKE_ID, CRYPTO,
                     CRYPTO_PACKET_FRIEND_REQ};
@@ -466,7 +466,7 @@ struct Contact {
 
 impl Contact {
     fn new() -> Contact {
-        let mut contact: Contact = unsafe { mem::init() };
+        let mut contact: Contact = unsafe { mem::zeroed() };
         contact.data_key = None;
         contact
     }
@@ -624,7 +624,7 @@ impl Client {
         if nospam.as_slice() != self.nospam {
             return other_error();
         }
-        let msg: ~str = try!(data.read_struct());
+        let msg: String = try!(data.read_struct());
         self.messenger.friend_request(source, msg);
         Ok(())
     }

--- a/onion/pipe.rs
+++ b/onion/pipe.rs
@@ -55,7 +55,7 @@ struct Contact {
 impl Contact {
     fn new() -> Contact {
         // Maybe use uninit?
-        unsafe { mem::init() }
+        unsafe { mem::zeroed() }
     }
 
     fn timed_out(&self) -> bool {
@@ -182,7 +182,7 @@ impl Onion {
                         let c = self.contacts.get_mut(p);
                         c.id        = id;
                         c.addr      = source;
-                        c.private   = Vec::from_slice(return_path);
+                        c.private   = Vec::from_slice(return_path.as_slice());
                         c.data_key  = data_key;
                         c.timestamp = utils::time::sec();
                     }
@@ -236,9 +236,9 @@ impl Onion {
             let nonce = Nonce::random();
             let mut packet = MemWriter::new();
             try!(packet.write_u8(LEVEL2_RESPONSE));
-            try!(packet.write(return_path));
+            try!(packet.write(return_path.as_slice()));
             try!(packet.write_u8(META_RESPONSE));
-            try!(packet.write(send_back));
+            try!(packet.write(send_back.as_slice()));
             try!(packet.write_struct(&nonce));
             try!(packet.write_encrypted(&our_key.with_nonce(&nonce),
                                         encrypted.as_slice()));

--- a/ping.rs
+++ b/ping.rs
@@ -11,7 +11,7 @@ use utils::{other_error, StructReader, StructWriter, CryptoReader, CryptoWriter}
 use utils::ringbuffer::{RingBuffer};
 use net::sockets::{UdpWriter};
 use keylocker::{Keylocker};
-use rand::{task_rng, Rng};
+use std::rand::{task_rng, Rng};
 
 /// Maximum number of peers whose pongs we're waiting for.
 static MAX_PINING: uint = 512;

--- a/utils/mod.rs
+++ b/utils/mod.rs
@@ -3,7 +3,7 @@ use std::io::{IoResult, MemWriter, MemReader, OtherIoError, standard_error,
 use crypt::Machine;
 use std::str::{from_utf8};
 
-pub mod ringbuffer;
+#[deprecated] pub mod ringbuffer;
 pub mod time;
 pub mod bufreader;
 
@@ -131,18 +131,20 @@ impl<'a> Writable for &'a [u32] {
     }
 }
 
-impl Readable for ~str {
-    fn read_from(r: &mut Reader) -> IoResult<~str> {
+impl Readable for String {
+    fn read_from(r: &mut Reader) -> IoResult<String> {
         let data = try!(r.read_to_end());
         match from_utf8(data.as_slice()) {
-            Some(string) => Ok(string.to_owned()),
+            Some(string) => Ok(string.to_string()),
             None => other_error(),
         }
     }
 }
 
+#[deprecated]
 pub fn parse_hex(s: &str, buf: &mut [u8]) -> Result<(),()> {
-    if s.len() != 2*buf.len() {
+    unimplemented!();
+/*    if s.len() != 2*buf.len() {
         return Err(());
     }
     for i in range(0u, buf.len()) {
@@ -155,7 +157,7 @@ pub fn parse_hex(s: &str, buf: &mut [u8]) -> Result<(),()> {
             }
         }
     }
-    return Ok(());
+    return Ok(());*/
 }
 
 pub trait LastN {

--- a/xot.rs
+++ b/xot.rs
@@ -5,28 +5,28 @@ use crypt::{Key};
 struct PeerChange;
 
 pub enum Event {
-    FriendRequest(Key, ~str),
-    FriendMessage(Key, ~str),
-    FriendAction(Key, ~str),
-    FriendName(Key, ~str),
-    FriendStatusMessage(Key, ~str),
+    FriendRequest(Key, String),
+    FriendMessage(Key, String),
+    FriendAction(Key, String),
+    FriendName(Key, String),
+    FriendStatusMessage(Key, String),
     FriendUserStatus(Key, UserStatus),
     FriendTyping(Key, bool),
     FriendReceipt(Key, u32),
     FriendOnline(Key, bool),
 
     GroupInvite(Key, Key),
-    GroupMessage(Key, Key, ~str),
-    GroupAction(Key, Key, ~str),
+    GroupMessage(Key, Key, String),
+    GroupAction(Key, Key, String),
     GroupNewPeer(Key, Key),
     GroupDelPeer(Key, Key),
-    GroupPeerName(Key, Key, ~str),
+    GroupPeerName(Key, Key, String),
 }
 
 pub struct FriendInfo {
     addr: ClientAddr,
-    name: ~str,
-    status_message: ~str,
+    name: String,
+    status_message: String,
     online: bool,
     last_seen: i64,
     user_status: UserStatus,
@@ -39,17 +39,17 @@ pub enum XotError {
 
 enum InfoType {
     GetAddress(Sender<ClientAddr>),
-    GetFriendName(Key, Sender<Option<~str>>),
-    GetName(Sender<~str>),
+    GetFriendName(Key, Sender<Option<String>>),
+    GetName(Sender<String>),
     GetFriendInfo(Key, Sender<Option<FriendInfo>>),
     GetFriends(Sender<Vec<FriendInfo>>),
-    GetStatusMessage(Sender<Option<~str>>),
+    GetStatusMessage(Sender<Option<String>>),
     GetUserStatus(Sender<UserStatus>),
 }
 
 enum Setting {
-    SetName(~str),
-    SetStatusMessage(~str),
+    SetName(String),
+    SetStatusMessage(String),
     SetUserStatus(UserStatus),
     SetNospam([u8, ..4]),
 }
@@ -58,10 +58,10 @@ type XotResult<T> = Result<T, XotError>;
 
 struct Xot {
     info: Sender<InfoType>,
-    friend_req: Sender<(ClientAddr, Option<~str>)>,
+    friend_req: Sender<(ClientAddr, Option<String>)>,
     friend_del: Sender<(Sender<XotResult<()>>, Key)>,
-    friend_msg: Sender<(Sender<XotResult<u32>>, Key, ~str)>,
-    friend_action: Sender<(Sender<XotResult<u32>>, Key, ~str)>,
+    friend_msg: Sender<(Sender<XotResult<u32>>, Key, String)>,
+    friend_action: Sender<(Sender<XotResult<u32>>, Key, String)>,
     settings: Sender<Setting>,
 }
 
@@ -72,7 +72,7 @@ impl Xot {
         rcv.recv()
     }
 
-    pub fn add_friend(&self, friend: &ClientAddr, msg: ~str) {
+    pub fn add_friend(&self, friend: &ClientAddr, msg: String) {
         self.friend_req.send((*friend, Some(msg)));
     }
 
@@ -86,39 +86,39 @@ impl Xot {
         rcv.recv()
     }
 
-    pub fn send_message(&self, friend: &Key, msg: ~str) -> XotResult<u32> {
+    pub fn send_message(&self, friend: &Key, msg: String) -> XotResult<u32> {
         let (snd, rcv) = channel();
         self.friend_msg.send((snd, *friend, msg));
         rcv.recv()
     }
 
-    pub fn send_action(&self, friend: &Key, msg: ~str) -> XotResult<u32> {
+    pub fn send_action(&self, friend: &Key, msg: String) -> XotResult<u32> {
         let (snd, rcv) = channel();
         self.friend_action.send((snd, *friend, msg));
         rcv.recv()
     }
 
-    pub fn set_name(&self, name: ~str) {
+    pub fn set_name(&self, name: String) {
         self.settings.send(SetName(name));
     }
 
-    pub fn get_name(&self) -> ~str {
+    pub fn get_name(&self) -> String {
         let (snd, rcv) = channel();
         self.info.send(GetName(snd));
         rcv.recv()
     }
 
-    pub fn get_friend_name(&self, friend: &Key) -> Option<~str> {
+    pub fn get_friend_name(&self, friend: &Key) -> Option<String> {
         let (snd, rcv) = channel();
         self.info.send(GetFriendName(*friend, snd));
         rcv.recv()
     }
 
-    pub fn set_status_message(&self, msg: ~str) {
+    pub fn set_status_message(&self, msg: String) {
         self.settings.send(SetStatusMessage(msg));
     }
 
-    pub fn get_status_message(&self) -> Option<~str> {
+    pub fn get_status_message(&self) -> Option<String> {
         let (snd, rcv) = channel();
         self.info.send(GetStatusMessage(snd));
         rcv.recv()


### PR DESCRIPTION
Subj. Also added `warn` target to show relevant complier warnings.
`parse_hex` tagged deprecated and unimplemented (should be replaced by serialize::hex).
